### PR TITLE
ensure start menu entry for uninstall points to the correct script

### DIFF
--- a/Install.sh
+++ b/Install.sh
@@ -139,7 +139,7 @@ rm -rf "$HOME"/.local/share/applications/UninstallR4SD.desktop 2>/dev/null
 echo "#!/usr/bin/env xdg-open
 [Desktop Entry]
 Name=Uninstall R4SD
-Exec=bash $HOME/.R4SD/RepairR4SD.sh
+Exec=bash $HOME/.R4SD/UninstallR4SD.sh
 Icon=btsync-gui
 Terminal=false
 Type=Application


### PR DESCRIPTION
While stepping through this script, I noticed that the Start Menu entry is not correctly set to the Uninstall script. No doubt a testament to it's non-usage, but wanted to provide a fix and a thanks for the script at the same time.